### PR TITLE
feat: 구글 로그인 redirect 구분 #2

### DIFF
--- a/mukpic/src/main/java/i4U/mukPic/global/auth/handler/OAuth2SuccessHandler.java
+++ b/mukpic/src/main/java/i4U/mukPic/global/auth/handler/OAuth2SuccessHandler.java
@@ -1,6 +1,8 @@
 package i4U.mukPic.global.auth.handler;
 
+import i4U.mukPic.global.auth.PrincipalDetails;
 import i4U.mukPic.global.jwt.security.JwtTokenProvider;
+import i4U.mukPic.user.entity.UserStatus;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -17,7 +19,7 @@ import java.io.IOException;
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private static final String URI = "http://localhost:8080";
+    private static final String BASE_URI = "http://localhost:8080";
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -26,11 +28,28 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         String accessToken = jwtTokenProvider.generateAccessToken(authentication);
         jwtTokenProvider.generateRefreshToken(authentication, accessToken);
 
-        // 토큰 전달을 위한 redirect
-        String redirectUrl = UriComponentsBuilder.fromUriString(URI)
-                .queryParam("accessToken", accessToken)
-                .build().toUriString();
+        // 사용자 정보 가져오기
+        if (authentication.getPrincipal() instanceof PrincipalDetails principalDetails) {
+            var user = principalDetails.user();
 
-        response.sendRedirect(redirectUrl);
+            // 조건에 따라 다른 redirect URL 설정
+            String redirectUrl;
+            if (user.getUpdatedAt() == null || user.getUserStatus() == UserStatus.INACTIVE) {
+                // updatedAt이 null이거나 userStatus가 INACTIVE인 경우
+                redirectUrl = UriComponentsBuilder.fromUriString(BASE_URI)
+                        .queryParam("accessToken", accessToken)
+                        .build().toUriString();
+            } else {
+                // 조건에 해당하지 않는 경우
+                redirectUrl = UriComponentsBuilder.fromUriString(BASE_URI + "/welcome")
+                        .queryParam("accessToken", accessToken)
+                        .build().toUriString();
+            }
+
+            // 리다이렉트 처리
+            response.sendRedirect(redirectUrl);
+        } else {
+            throw new IllegalArgumentException("Unexpected authentication principal type");
+        }
     }
 }

--- a/mukpic/src/main/java/i4U/mukPic/global/auth/service/CustomOAuth2UserService.java
+++ b/mukpic/src/main/java/i4U/mukPic/global/auth/service/CustomOAuth2UserService.java
@@ -64,34 +64,29 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
                     existingUser.updateUserName(oAuth2UserInfo.name());
                     existingUser.updateImage(oAuth2UserInfo.profile());
-                    existingUser.updatePassword(oAuth2UserInfo.toEntity().getPassword());
+
+                    String existingPassword = oAuth2UserInfo.toEntity().getPassword();
+                    String encodedPassword = getPasswordEncoder().encode(existingPassword);
+                    existingUser.updatePassword(encodedPassword);
+
                     existingUser.updateAgree(oAuth2UserInfo.toEntity().getAgree());
 
-                    Allergy allergy = existingUser.getAllergy();
-                    if (allergy == null) {
-                        allergy = new Allergy();
+                    if (existingUser.getAllergy() == null) {
+                        Allergy allergy = new Allergy();
                         allergy.setUser(existingUser);
                         existingUser.setAllergy(allergy);
-                    } else {
-                        allergy.getAllergies().clear();
                     }
 
-                    ChronicDisease chronicDisease = existingUser.getChronicDisease();
-                    if (chronicDisease == null) {
-                        chronicDisease = new ChronicDisease();
+                    if (existingUser.getChronicDisease() == null) {
+                        ChronicDisease chronicDisease = new ChronicDisease();
                         chronicDisease.setUser(existingUser);
                         existingUser.setChronicDisease(chronicDisease);
-                    } else {
-                        chronicDisease.getDiseases().clear();
                     }
 
-                    DietaryPreference dietaryPreference = existingUser.getDietaryPreference();
-                    if (dietaryPreference == null) {
-                        dietaryPreference = new DietaryPreference();
+                    if (existingUser.getDietaryPreference() == null) {
+                        DietaryPreference dietaryPreference = new DietaryPreference();
                         dietaryPreference.setUser(existingUser);
                         existingUser.setDietaryPreference(dietaryPreference);
-                    } else {
-                        dietaryPreference.getPreferences().clear();
                     }
 
                     return userRepository.save(existingUser);

--- a/mukpic/src/main/java/i4U/mukPic/user/controller/LoginController.java
+++ b/mukpic/src/main/java/i4U/mukPic/user/controller/LoginController.java
@@ -1,6 +1,5 @@
 package i4U.mukPic.user.controller;
 
-import i4U.mukPic.global.auth.TokenKey; // TokenKey 클래스 임포트
 import i4U.mukPic.user.dto.LoginRequestDTO;
 import i4U.mukPic.user.service.LoginService;
 import jakarta.validation.Valid;
@@ -28,11 +27,11 @@ public class LoginController {
         Map<String, Object> responseBody = new HashMap<>();
         responseBody.put("status", "success");
         responseBody.put("message", "Login successful");
-        responseBody.put("refreshToken", tokens.get("refreshToken"));
 
         // 응답 헤더 추가
         HttpHeaders headers = new HttpHeaders();
         headers.add("Authorization", "Bearer " + tokens.get("accessToken"));
+        headers.add("refreshToken", tokens.get("refreshToken"));
 
         return ResponseEntity.ok()
                 .headers(headers)

--- a/mukpic/src/main/java/i4U/mukPic/user/repository/UserRepository.java
+++ b/mukpic/src/main/java/i4U/mukPic/user/repository/UserRepository.java
@@ -2,10 +2,12 @@ package i4U.mukPic.user.repository;
 
 import i4U.mukPic.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 
 import java.util.Optional;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUserId(String userId);

--- a/mukpic/src/main/java/i4U/mukPic/user/service/UserService.java
+++ b/mukpic/src/main/java/i4U/mukPic/user/service/UserService.java
@@ -8,6 +8,7 @@ import i4U.mukPic.user.dto.UserResponseDTO;
 import i4U.mukPic.user.entity.*;
 import i4U.mukPic.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;


### PR DESCRIPTION
refreshToken 헤더로 변경
구글 로그인 유저 redirect 구분(최초가입/가입된 유저-재가입도 포함)
구글 재가입 비밀번호 암호화
구글 재가입 기존 데이터 복구