### PR TITLE
fix: 게시글 조회 시 이미지 연결 수정 #14

### DIFF
--- a/mukpic/src/main/java/i4U/mukPic/community/controller/CommunityController.java
+++ b/mukpic/src/main/java/i4U/mukPic/community/controller/CommunityController.java
@@ -3,7 +3,6 @@ package i4U.mukPic.community.controller;
 import i4U.mukPic.community.dto.CommunityRequestDto;
 import i4U.mukPic.community.dto.CommunityResponseDto;
 import i4U.mukPic.community.entity.Category;
-import i4U.mukPic.community.entity.Community;
 import i4U.mukPic.community.service.CommunityService;
 import i4U.mukPic.user.entity.User;
 import i4U.mukPic.user.service.UserService;
@@ -33,8 +32,7 @@ public class CommunityController {
     public ResponseEntity postCommunityFeed (@Valid @RequestBody CommunityRequestDto.Post postDto,
                                              HttpServletRequest request){
         User user = userService.getUserFromRequest(request);
-        Community community = communityService.createCommunityFeed(postDto, user);
-        CommunityResponseDto responseDto = new CommunityResponseDto(community, community.getImageUrl());
+        CommunityResponseDto responseDto = communityService.createCommunityFeed(postDto, user);
 
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
@@ -79,20 +77,18 @@ public class CommunityController {
     //커뮤니티 글 상세 조회
     @GetMapping("{community-key}")
     public ResponseEntity getCommunityFeed (@PathVariable ("community-key") Long communityKey){
-        Community community = communityService.findCommunityById(communityKey);
-        CommunityResponseDto communityResponseDto = new CommunityResponseDto(community, community.getImageUrl());
+        CommunityResponseDto responseDto = communityService.findCommunityById(communityKey);
 
-        return new ResponseEntity(communityResponseDto, HttpStatus.OK);
+        return new ResponseEntity(responseDto, HttpStatus.OK);
     }
 
 
     //커뮤니티 글 수정
     @PatchMapping("{community-key}")
     public ResponseEntity patchCommunityFeed (@PathVariable ("community-key") Long communityKey, @RequestBody CommunityRequestDto.Patch patchDto){
-        Community community = communityService.updateFeed(communityKey, patchDto);
-        CommunityResponseDto communityResponseDto = new CommunityResponseDto(community, community.getImageUrl());
+        CommunityResponseDto responseDto = communityService.updateFeed(communityKey, patchDto);
 
-        return new ResponseEntity<>(communityResponseDto, HttpStatus.OK);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
     //커뮤니티 글 삭제
@@ -101,7 +97,6 @@ public class CommunityController {
         communityService.deleteCommunityFeed(communityKey);
         return new ResponseEntity<>(HttpStatus.ACCEPTED);
     }
-
 
 
 }

--- a/mukpic/src/main/java/i4U/mukPic/community/dto/CommunityRequestDto.java
+++ b/mukpic/src/main/java/i4U/mukPic/community/dto/CommunityRequestDto.java
@@ -22,6 +22,7 @@ public class CommunityRequestDto {
 
         // 이미지 URL 리스트의 크기를 5개로 제한
         @Size(max = 5, message = "이미지는 최대 5개까지 업로드할 수 있습니다.")
+        @NotEmpty
         private List<String> imageUrl;
 
         @NotBlank

--- a/mukpic/src/main/java/i4U/mukPic/community/dto/CommunityResponseDto.java
+++ b/mukpic/src/main/java/i4U/mukPic/community/dto/CommunityResponseDto.java
@@ -13,16 +13,15 @@ public class CommunityResponseDto {
     private Long communityKey;
     private String title;
     private String content;
-    private List<Image> imageUrls;
+    private List<String> imageUrls;
     private int likeCount;
 
-    public CommunityResponseDto(Community community, List<Image> imageUrls){
+    public CommunityResponseDto(Community community, List<String> imageUrls){
         this.communityKey = community.getCommunityKey();
         this.title = community.getTitle();
         this.content= community.getContent();
         this.imageUrls = imageUrls;
         this.likeCount = community.getLikeCount();
     }
-
 
 }


### PR DESCRIPTION
게시글 조회 시 연결된 이미지가 함께 조회되지 않는 오류가 있어 수정했습니다. 
+ 게시글 등록 시 이미지 URL이 없으면 작성할 수 없도록 @NotEmpty 처리 추가했습니다. 