### PR TITLE
fix: Category enum 값에 ALL 추가 #14

### DIFF
--- a/mukpic/src/main/java/i4U/mukPic/MukPicApplication.java
+++ b/mukpic/src/main/java/i4U/mukPic/MukPicApplication.java
@@ -2,8 +2,10 @@ package i4U.mukPic;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class MukPicApplication {
 
 	public static void main(String[] args) {

--- a/mukpic/src/main/java/i4U/mukPic/community/controller/CommunityController.java
+++ b/mukpic/src/main/java/i4U/mukPic/community/controller/CommunityController.java
@@ -42,13 +42,15 @@ public class CommunityController {
     public ResponseEntity<Page<CommunityResponseDto>> getCommunityFeeds(
             @RequestParam(defaultValue = "ALL") Category category,
             @RequestParam(defaultValue = "latest") String sortBy,
-            Pageable pageable) {
+            HttpServletRequest request, Pageable pageable) {
+
+        User user = userService.getUserFromRequest(request);
         Page<CommunityResponseDto> responseDtos;
 
         if ("ALL".equalsIgnoreCase(String.valueOf(category))) {
-            responseDtos = communityService.getAllCommunityFeeds(sortBy, pageable);
+            responseDtos = communityService.getAllCommunityFeeds(sortBy, pageable, user);
         } else {
-            responseDtos = communityService.getCommunityFeedsByCategory(category, sortBy, pageable);
+            responseDtos = communityService.getCommunityFeedsByCategory(category, sortBy, pageable, user);
         }
 
         return new ResponseEntity<>(responseDtos, HttpStatus.OK);
@@ -59,7 +61,7 @@ public class CommunityController {
     public ResponseEntity getMyCommunityFeed (HttpServletRequest request, Pageable pageable) {
 
         User user = userService.getUserFromRequest(request);
-        Page<CommunityResponseDto> myCommunities = communityService.findMyCommunityFeeds(user.getUserKey(), pageable);
+        Page<CommunityResponseDto> myCommunities = communityService.findMyCommunityFeeds(user, pageable);
 
         return new ResponseEntity<>(myCommunities, HttpStatus.OK);
 
@@ -69,15 +71,16 @@ public class CommunityController {
     @GetMapping("/likedCommunities")
     public ResponseEntity getLikedCommunities(HttpServletRequest request, Pageable pageable) {
         User user = userService.getUserFromRequest(request);
-        Page<CommunityResponseDto> likedCommunities = communityService.findLikedCommunities(user.getUserKey(), pageable);
+        Page<CommunityResponseDto> likedCommunities = communityService.findLikedCommunities(user, pageable);
 
         return new ResponseEntity<>(likedCommunities, HttpStatus.OK);
     }
 
     //커뮤니티 글 상세 조회
     @GetMapping("{community-key}")
-    public ResponseEntity getCommunityFeed (@PathVariable ("community-key") Long communityKey){
-        CommunityResponseDto responseDto = communityService.findCommunityById(communityKey);
+    public ResponseEntity getCommunityFeed (@PathVariable ("community-key") Long communityKey, HttpServletRequest request){
+        User user = userService.getUserFromRequest(request);
+        CommunityResponseDto responseDto = communityService.findCommunityById(communityKey, user);
 
         return new ResponseEntity(responseDto, HttpStatus.OK);
     }
@@ -85,8 +88,10 @@ public class CommunityController {
 
     //커뮤니티 글 수정
     @PatchMapping("{community-key}")
-    public ResponseEntity patchCommunityFeed (@PathVariable ("community-key") Long communityKey, @RequestBody CommunityRequestDto.Patch patchDto){
-        CommunityResponseDto responseDto = communityService.updateFeed(communityKey, patchDto);
+    public ResponseEntity patchCommunityFeed (@PathVariable ("community-key") Long communityKey, @RequestBody CommunityRequestDto.Patch patchDto,
+                                              HttpServletRequest request){
+        User user = userService.getUserFromRequest(request);
+        CommunityResponseDto responseDto = communityService.updateFeed(communityKey, patchDto,user);
 
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }

--- a/mukpic/src/main/java/i4U/mukPic/community/dto/CommunityResponseDto.java
+++ b/mukpic/src/main/java/i4U/mukPic/community/dto/CommunityResponseDto.java
@@ -1,10 +1,10 @@
 package i4U.mukPic.community.dto;
 
 import i4U.mukPic.community.entity.Community;
-import i4U.mukPic.image.entity.Image;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -14,14 +14,27 @@ public class CommunityResponseDto {
     private String title;
     private String content;
     private List<String> imageUrls;
+    private String category;
     private int likeCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
-    public CommunityResponseDto(Community community, List<String> imageUrls){
+    private String userName;
+    private String profileImage;
+    private boolean isLiked;
+
+    public CommunityResponseDto(Community community, List<String> imageUrls, boolean isLiked){
         this.communityKey = community.getCommunityKey();
         this.title = community.getTitle();
         this.content= community.getContent();
         this.imageUrls = imageUrls;
+        this.category= community.getCategory().toString();
         this.likeCount = community.getLikeCount();
+        this.createdAt = community.getCreatedAt();
+        this.updatedAt = community.getUpdatedAt();
+        this.userName = community.getUser().getUserName();
+        this.profileImage = community.getUser().getImage();
+        this.isLiked = isLiked;
     }
 
 }

--- a/mukpic/src/main/java/i4U/mukPic/community/entity/Category.java
+++ b/mukpic/src/main/java/i4U/mukPic/community/entity/Category.java
@@ -1,5 +1,5 @@
 package i4U.mukPic.community.entity;
 
 public enum Category {
-    RICE, NOODLE
+   ALL, RICE, NOODLE
 }


### PR DESCRIPTION
- 커뮤니티 게시글 전체 조회 API 요청 시 
    - category 값 ALL 으로 보내면 전체 게시글 조회 됩니다. 
    - category와 sortBy 값은 없이 보내면 기본 값(ALL, latest)으로 조회됩니다.
        -  ex_ {{URL}}/community?page=0&size=10

- 게시글 정보 보내줄 때 
    - 사용자 이름 : userName
    - 사용자 프로필 이미지: profileImage
    - 게시글 생성일: createdAt
    - 게시글 수정일: updatedAt
    - 게시글 좋아요 수: likedCount
    - 게시글 카테고리: category
    - 사용자가 게시글 좋아요 했는지 여부: liked (true OR false)
    
값 보내도록 추가했습니다. 
